### PR TITLE
fix cross browser dates

### DIFF
--- a/script.js
+++ b/script.js
@@ -536,7 +536,11 @@ async function fetchData(username, year, hue) {
     const cellId = `x${Math.floor(dayIncrement / 7)}-y${dayIncrement % 7}`;
     const dataCell = document.querySelector(`[data-coord="${cellId}"`);
     const options = { weekday: "long", year: "numeric", month: "long", day: "numeric" };
-    const datePretty = new Date(dateString).toLocaleDateString("en-US", options);
+
+    // ensure cross-browser compatibility with standardized date
+    const dateParts = dateString.split(".");
+    const standardizedDate = `${dateParts[0]}-${dateParts[1]}-${dateParts[2]}`;
+    const datePretty = new Date(standardizedDate).toLocaleDateString("en-US", options);
 
     if (gameData.hasOwnProperty(dateString)) {
       const totalGames = gameData[dateString]["total"];


### PR DESCRIPTION
The reason we an "invalid date" error when using the toLocaleDateString function on Safari is because Safari requires the date string to be in a specific format.

While Chrome is able to parse the date string "2022.05.01" as a valid date, Safari may not be able to do the same.

To ensure cross-browser compatibility we'll use a standardized date format such as "YYYY-MM-DD" or "YYYY/MM/DD". We use the split() method to split the date string and construct a new date object using the standardized format, like this:

```js
const dateParts = dateString.split('.');
const standardizedDate = `${dateParts[0]}-${dateParts[1]}-${dateParts[2]}`;
const datePretty = new Date(standardizedDate).toLocaleDateString("en-US", options);
```