### PR TITLE
Change fethching endpoint to work with json instead of pgn

### DIFF
--- a/script.js
+++ b/script.js
@@ -440,13 +440,14 @@ async function fetchData(username, year, hue) {
       loopYear = String(year);
     }
 
-    const url = `https://api.chess.com/pub/player/${user}/games/${loopYear}/${loopMonth}/pgn`;
+    const url = `https://api.chess.com/pub/player/${user}/games/${loopYear}/${loopMonth}`;
     const response = await fetch(url);
     if (!response.ok) throw new Error('Failed to fetch data');
-    const data = await response.text();
+    const { games } = await response.json();
 
-    const pgns = data.split('\n\n\n');
-    if (!pgns || pgns[0] === '') continue; // Skip months with no games
+    if (games.length === 0) continue; // Skip months with no games
+
+    const pgns = games.map((game) => game.pgn);
 
     for (let j = 0; j < pgns.length; j++) {
       const annotationRegex = /\[(\w+)\s+\"(.+?)\"\]/g;


### PR DESCRIPTION
Response from not `/pgn` endpoint also have a pgn inside the json. So only you should do is to extract pgns from that.
It faster only because of json compression. It uses less traffic, regardless the fact we got more info.

I'm attaching screenshots before/after
user: hikaru

before: 11.7 MB

![image](https://user-images.githubusercontent.com/54411613/236114268-010c822e-5180-43b7-aea3-1a55b65c40d1.png)

after: 3.5 MB

![image](https://user-images.githubusercontent.com/54411613/236114396-e4d275cb-6ad9-4302-87d2-83f27bb730eb.png)

If you want to optimize more, you always can get rid of regex, but for now it looks good for me.