### PR TITLE
Added caching mechanism for API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'S
 const MONTHS_LONG = ['January', 'Febuary', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 const DAYS_OF_THE_WEEK = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const CURR_YEAR = new Date().getFullYear();
+const CURR_MONTH = String(new Date().getMonth() + 1).padStart(2, '0');
 
 const currentTooltip = document.createElement('div');
 currentTooltip.classList.add('svg-tip', 'svg-tip-one-line');
@@ -143,7 +144,7 @@ function isValidChessComYear(year) {
 function setValidHue(value) {
   const num_mod = value % 360;
   if (num_mod < 0) return num_mod + 360;
-  return num_mod
+  return num_mod;
 }
 
 function generateTable() {
@@ -422,14 +423,21 @@ async function fetchData(username, year, hue) {
 
     const url = `https://api.chess.com/pub/player/${user}/games/${loopYear}/${loopMonth}`;
 
-    if (archives.includes(url)) validArchives.push(url);
+    if (archives.includes(url)) {
+      validArchives.push({
+        url: url,
+        month: loopMonth,
+        year: loopYear,
+      });
+    }
   }
 
   for (let i = 0; i < validArchives.length; i++) {
-    const url = validArchives[i];
-    const response = await fetch(url);
-    if (!response.ok) throw new Error('Failed to fetch data');
-    const { games } = await response.json();
+    const { url, month, year } = validArchives[i];
+    const isShouldSkipCaching = month === CURR_MONTH && year === String(CURR_YEAR);
+
+    const cacheData = await getData(url, isShouldSkipCaching);
+    const games = cacheData.games;
 
     for (let j = 0; j < games.length; j++) {
       const currGameDate = new Date(games[j].end_time * 1000);
@@ -636,3 +644,32 @@ document.getElementById('copy-button').addEventListener('click', async function 
   alert('Link copied to clipboard!');
 });
 /* End form logic */
+
+// Try to get data from the cache, but fall back to fetching it live.
+async function getData(url, skipCaching) {
+  const cacheVersion = 1;
+  const cacheName = `myapp-${cacheVersion}`;
+  let cachedData;
+
+  if (!skipCaching) cachedData = await getCachedData(cacheName, url);
+
+  if (cachedData) return cachedData;
+
+  const cacheStorage = await caches.open(cacheName);
+  await cacheStorage.add(url);
+  cachedData = await getCachedData(cacheName, url);
+
+  return cachedData;
+}
+
+// Get data from the cache.
+async function getCachedData(cacheName, url) {
+  const cacheStorage = await caches.open(cacheName);
+  const cachedResponse = await cacheStorage.match(url);
+
+  if (!cachedResponse || !cachedResponse.ok) {
+    return false;
+  }
+
+  return await cachedResponse.json();
+}


### PR DESCRIPTION
We can't use localStorage to store data, because it's limited to 5 MB.

Now application caches all api calls for all user archives besides current year and month.
Tested on users: hikaru, danielnaroditsky, k0m, bahanovych
For years: 2020, 2021, 2022, 2023

If data for certain user already is in cache storage and it isn't current year, there isn't a single api call for user games archive.

If data for certain user already is in cache storage and it is current year, there is only 1 api call for user games archive for current month (no need in data from previous months when it's already in cache storage).