### PR TITLE
Do not cache the current month's response data

### DIFF
--- a/script.js
+++ b/script.js
@@ -718,8 +718,10 @@ async function getData(url, skipCaching) {
     throw new Error('Failed to fetch data');
   }
 
-  const cacheStorage = await caches.open(cacheName);
-  cacheStorage.put(url, response.clone());
+  if (!skipCaching) {
+    const cacheStorage = await caches.open(cacheName);
+    cacheStorage.put(url, response.clone());
+  }
 
   return response.json();
 }


### PR DESCRIPTION
This would be in the scenario when someone generated a chess heatmap on 5.16 and didn't re-generate a chess heatmap for 15 days. Then it would be 6.01 now. They cannot get data from days 16-31, because we were caching the current month data and it's now the next month.

This PR fixes that by not caching the current month 👍🏻